### PR TITLE
Getting compatability with multisite installs

### DIFF
--- a/lib/admin_page.php
+++ b/lib/admin_page.php
@@ -150,5 +150,5 @@ function p7i_bootstrap_js() {
  * @return string
  */
 function p7i_get_admin_page_url() {
-    return admin_url('admin.php?page=prophoto-installer');
+    return admin_url('admin.php?page=p7-installer');
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1,5 +1,16 @@
 <?php
 
+function p7i_init() {
+    if (p7i_is_active_theme()) {
+        return;
+    }
+
+    p7i_test_drive_init();
+    add_action('admin_menu', 'p7i_add_menu_item');
+    add_action('load-toplevel_page_p7-installer', 'p7i_admin_page_init');
+    add_action('admin_enqueue_scripts', 'p7i_pointer_init');
+}
+
 /**
  * Get the unique installer plugin registration data, if available
  *

--- a/lib/pointer.php
+++ b/lib/pointer.php
@@ -19,7 +19,7 @@ function p7i_pointer_init() {
 
    wp_localize_script('ppi_pointer', 'ppi_pointer', array(
       'content' => p7i_pointer_markup(),
-      'target' => '.toplevel_page_prophoto-installer > a',
+      'target' => '.toplevel_page_p7-installer > a',
       'position' => array(
          'edge' => 'left',
          'align' => 'middle',

--- a/pp-installer.php
+++ b/pp-installer.php
@@ -19,15 +19,7 @@ foreach ((array) glob(P7I_DIR . '/lib/*.php') as $file) {
 }
 
 add_action('admin_head-widgets.php', 'p7i_prevent_delete_inactive_widgets');
-
-if (p7i_is_active_theme()) {
-    return;
-}
-
-add_action('plugins_loaded', 'p7i_test_drive_init');
 add_action('wp_ajax_ppi_api', 'p7i_api_route_request');
-add_action('admin_menu', 'p7i_add_menu_item');
-add_action('load-toplevel_page_p7-installer', 'p7i_admin_page_init');
-add_action('admin_enqueue_scripts', 'p7i_pointer_init');
+add_action('plugins_loaded', 'p7i_init');
 add_action('pp_container_binding', 'p7i_container_bindings');
 register_deactivation_hook(__FILE__, 'p7i_deactivation');


### PR DESCRIPTION
For some reason, only in a multi-site environment, you need to put any calls to wp_get_themes() in the plugins_loaded action or later, or it returns an empty array.  Tested to make sure this still works in non-mu.